### PR TITLE
update poll: update stdin handling (add eof, i.e. ctrl+d)

### DIFF
--- a/srcs/server/poll.hpp
+++ b/srcs/server/poll.hpp
@@ -198,9 +198,8 @@ class Poll {
 	}
 	void	_handle_stdin() {
 		std::string line;
-		std::getline(std::cin, line);
 
-		if (line == "quit" || line == "exit") {
+		if (!std::getline(std::cin, line) || line == "quit" || line == "exit") {
 			_alive = false;
 			std::cout << "Shutting down Webserv gracefully..." << std::endl;
 		}


### PR DESCRIPTION
Old code wasn't handling ctrl+d to left the server properly from stdin.
![oldIssue](https://user-images.githubusercontent.com/55627383/143511048-29f237ee-bfd0-4ab3-9a3c-e30a06bbe45d.png)

New code allow to close server by sending eof from stdin.
![newIssue](https://user-images.githubusercontent.com/55627383/143511084-68f2dd24-972f-400e-906a-dfbbb8b4994d.png)

