### PR TITLE
update enums: remove type (int) in enum declaration

### DIFF
--- a/srcs/models/enums.hpp
+++ b/srcs/models/enums.hpp
@@ -6,7 +6,7 @@
 namespace Webserv {
 namespace Models {
 
-enum EMethods : int {
+enum EMethods {
 	GET = 0,
 	POST,
 	DELETE,
@@ -14,7 +14,7 @@ enum EMethods : int {
 	METHOD_UNKNOWN
 };
 
-enum ERead : int {
+enum ERead {
 	READ_OK = 0,
 	READ_EOF,
 	READ_ERROR


### PR DESCRIPTION
When type is removed in enum declaration, for EMethods and ERead, compilation works.