### PR TITLE
Update in parsing requests from clients

### DIFF
--- a/srcs/http/client.hpp
+++ b/srcs/http/client.hpp
@@ -65,19 +65,6 @@ class Client {
 	}
 
 	ERead read_request() {
-		std::cout << "check" << std::endl;
-		const size_t chunk_size = _last_request ? _last_request->get_chunk_size() : 0;
-		if (chunk_size != 0) {
-			char buffer[chunk_size + 1];
-			ssize_t n = recv(_fd, buffer, chunk_size, 0);
-			std::cout << n << std::endl;
-			if (n != (ssize_t)chunk_size) {
-				return Models::READ_ERROR;
-			}
-			buffer[chunk_size] = '\0';
-			std::cout << buffer << std::endl;
-			_last_request->handle_buffer(buffer);
-		}
 		char buffer[REQ_BUF_SIZE + 1] = {0};
 		ssize_t n = recv(_fd, buffer, REQ_BUF_SIZE, 0);
 		if (n == -1) {
@@ -85,7 +72,6 @@ class Client {
 		} else if (n == 0) {
 			return Models::READ_EOF;
 		} else {
-			std::cout << buffer << std::endl;
 			if (_last_request == NULL) {
 				_last_request = new Request(buffer);
 				_last_ping = *(_last_request->get_time());

--- a/srcs/http/client.hpp
+++ b/srcs/http/client.hpp
@@ -77,9 +77,9 @@ class Client {
 				_last_ping = *(_last_request->get_time());
 			}
 			else {
-				_last_request->parse_content(buffer);
+				_last_request->init(buffer);
 			}
-			return _request_status(buffer);
+			return _request_status();
 		}
 	}
 
@@ -98,29 +98,14 @@ class Client {
 	}
 
  private:
-	ERead	_request_status(std::string buffer) {
-		if (
-			_last_request->get_header_value("Content-Type") == "application/x-www-form-urlencoded"
-			&& _last_request->get_headers_status() == true
-		) {
-			return Models::READ_OK;
-		}
-		else if (buffer != "\r\n") {
+	ERead	_request_status() {
+		const std::string request = _last_request->get_raw_request();
+		if (request.find("\r\n\r\n") == std::string::npos) {
 			return Models::READ_WAIT;
 		}
 		else {
-			if (_last_request->get_method() == Models::POST) {
-				if (_last_request->get_headers_status() == false) {
-					_last_request->set_headers_status(true);
-					return Models::READ_WAIT;
-				}
-				else {
-					return Models::READ_OK;
-				}
-			}
-			else {
-				return Models::READ_OK;
-			}
+			_last_request->parse();
+			return Models::READ_OK;
 		}
 	}
 

--- a/srcs/http/request.hpp
+++ b/srcs/http/request.hpp
@@ -14,6 +14,7 @@ namespace Http {
 class Request {
 	typedef std::map<std::string, std::string>::const_iterator	const_iterator;
 	typedef Webserv::Models::EMethods							EMethod;
+	typedef Webserv::Models::EPostForm							EPostForm;
 
  private:
 	struct timeval _time;
@@ -27,18 +28,28 @@ class Request {
 	std::map<std::string, std::string>	_headers;
 	std::map<std::string, std::string>	_body;
 
+	EPostForm	_post_form;
+	size_t		_body_size;
+	std::string	_body_boundary;
+
+	bool	_headers_ready;
+	bool	_body_ready;
+	bool	_chunked;
 	bool	_closed;
 
  public:
 	explicit Request(std::string buffer) : _raw_request(buffer),
 		_method(Models::METHOD_UNKNOWN), _uri(""), _http_version(""),
-		_headers(), _closed(false) {
+		_headers(), _body(),
+		_post_form(Models::POST_FORM_UNKNOWN), _body_size(0), _body_boundary(""),
+		_headers_ready(false), _body_ready(false),
+		_chunked(false), _closed(false) {
 		gettimeofday(&_time, NULL);
 	}
 
-	void	init(std::string buffer) { _raw_request += buffer; }
+	void	handle_buffer(std::string buffer) { _raw_request += buffer; }
 
-	void	parse() {
+	void	init() {
 		if (!_extract_method(&_raw_request))
 			return;
 		if (!_extract_uri(&_raw_request))
@@ -46,15 +57,79 @@ class Request {
 		if (!_extract_http_version(&_raw_request))
 			return;
 		_extract_headers(&_raw_request);
-		if (_method == Models::POST)
-			_extract_body(&_raw_request);
-		__repr__();
+		const_iterator it = _headers.find("Host");
+		if (it == _headers.end() || it->second == "") {
+			_bad_request();
+			return ;
+		}
+		it = _headers.find("Transfer-Encoding");
+		if (it != _headers.end() && it->second.find("chunked") != std::string::npos) {
+			_chunked = true;
+		}
+		if (_method == Models::POST) {
+			it = _headers.find("Content-Type");
+			if (it == _headers.end()) {
+				_bad_request();
+				return ;
+			}
+			if (it->second.find("application/x-www-form-urlencoded") == 0) {
+				_post_form = Models::URLENCODED;
+				if (_chunked == false) {
+					it = _headers.find("Content-Length");
+					if (it == _headers.end()) {
+						_bad_request();
+						return ;
+					}
+					_body_size = static_cast<size_t>(atoi(it->second.c_str()));
+				}
+			}
+			else if (it->second.find("multipart/form-data") == 0) {
+				_post_form = Models::MULTIPART;
+				size_t boundary_start = it->second.find("boundary");
+				if (boundary_start == std::string::npos) {
+					_bad_request();
+					return ;
+				}
+				boundary_start += 10;
+				size_t boundary_size = it->second.substr(boundary_start).find("\"");
+				if (boundary_size == std::string::npos) {
+					_bad_request();
+					return ;
+				}
+				_body_boundary = "--" + it->second.substr(boundary_start, boundary_size);
+			}
+		}
+		_raw_request = _raw_request.substr(2);
 	}
 
-	bool	bad_request() {
-		std::cout << "Bad request" << std::endl;
-		_closed = true;
-		return false;
+	void	read_body() {
+		if (_chunked == true) {
+			if (_raw_request.find("0\r\n\r\n") == std::string::npos) {
+				return ;
+			}
+			// do decoding and clean buffer (_raw_request);
+			_body_size = _raw_request.size();
+			_chunked = false;
+		}
+		else {
+			if (_post_form == Models::URLENCODED) {
+				if (_raw_request.size() < _body_size) {
+					return ;
+				}
+				_raw_request = _raw_request.substr(0, _body_size);
+				_extract_urlencoded();
+				_body_ready = true;
+			}
+			else if (_post_form == Models::MULTIPART) {
+				const std::string end_boundary = _body_boundary + "--";
+				if (_raw_request.find(end_boundary) == std::string::npos) {
+					return ;
+				}
+				_raw_request = _raw_request.substr(0, _raw_request.size() - end_boundary.size());
+				_extract_multipart();
+				_body_ready = true;
+			}
+		}
 	}
 
 	bool	closed() {
@@ -69,6 +144,25 @@ class Request {
 		}
 		return _closed;
 	}
+
+	const struct timeval *get_time() const { return &_time; }
+	std::string get_raw_request() const { return _raw_request; };
+	EMethod		get_method() const { return _method; }
+	std::string get_uri() const { return _uri; }
+	std::string get_header_value(const std::string &headerName) const {
+		const_iterator it = _headers.find(headerName);
+		if (it == _headers.end()) {
+			return "";
+		}
+		else {
+			return it->second;
+		}
+	}
+	bool		get_header_status() const { return _headers_ready; }
+	bool		get_body_status() const { return _body_ready; }
+	bool		get_chunked_status() const { return _chunked; }
+
+	void		set_header_status(bool status) { _headers_ready = status; }
 
 	void	__repr__() {
 		std::cout << "Request{method: " << Models::resolve_method(_method)
@@ -86,25 +180,11 @@ class Request {
 		}
 	}
 
-	std::string get_raw_request() const { return _raw_request; };
-	EMethod		get_method() const { return _method; }
-	std::string get_uri() const { return _uri; }
-	std::string get_header_value(const std::string &headerName) const {
-		const_iterator it = _headers.find(headerName);
-		if (it == _headers.end()) {
-			return "";
-		}
-		else {
-			return it->second;
-		}
-	}
-	const struct timeval *get_time() const { return &_time; }
-
  private:
 	bool	_extract_method(std::string *buffer) {
 		size_t	method_separator_pos = buffer->find(" ");
 		if (method_separator_pos == std::string::npos)
-			return bad_request();
+			return _bad_request();
 
 		std::string	method_str = buffer->substr(0, method_separator_pos);
 		_method = Models::get_method(method_str);
@@ -115,7 +195,7 @@ class Request {
 	bool	_extract_uri(std::string *buffer) {
 		size_t	uri_separator_pos = buffer->find(" ");
 		if (uri_separator_pos == std::string::npos)
-			return bad_request();
+			return _bad_request();
 
 		_uri = buffer->substr(0, uri_separator_pos);
 		buffer->erase(0, uri_separator_pos + 1);
@@ -125,7 +205,7 @@ class Request {
 	bool	_extract_http_version(std::string *buffer) {
 		size_t	version_separator_pos = buffer->find("\r\n");
 		if (version_separator_pos == std::string::npos)
-			return bad_request();
+			return _bad_request();
 
 		_http_version = buffer->substr(0, version_separator_pos);
 		buffer->erase(0, version_separator_pos + 2);
@@ -139,44 +219,65 @@ class Request {
 			size_t		header_name_separator_pos = header_str.find(":");
 			if (header_name_separator_pos == std::string::npos)
 				break;
-
 			std::string	header_name = header_str.substr(0, header_name_separator_pos);
-			std::string	header_value = header_str.substr(header_name_separator_pos + 2);
+			std::string	header_content = header_str.substr(header_name_separator_pos + 1);
+			std::string header_value = _trim(header_content);
 			_headers[header_name] = header_value;
 			buffer->erase(0, header_separator_pos + 2);
 			header_separator_pos = buffer->find("\r\n");
 		}
 	}
 
-	void	_extract_body(std::string *buffer) {
-		const_iterator form_type = _headers.find("Content-Type");
-		if (form_type != _headers.end()) {
-			if (form_type->second == "application/x-www-form-urlencoded") {
-				*buffer = buffer->substr(2);
-				const_iterator content_length = _headers.find("Content-Length");
-				if (content_length == _headers.end()) {
-					return ;	// Invalid x-www-form-urlencoded request: missing content length.
-				}
-				if (buffer->size() != static_cast<size_t>(atoi(content_length->second.c_str()))) {
-					return ;	// Invalid x-www-form-urlencoded request: mismatching content length.
-				}
-				size_t body_separator_pos;
-				do {
-					body_separator_pos = buffer->find("&");
-					const std::string body_entry = buffer->substr(0, body_separator_pos);
-					const size_t body_entry_separator_pos = body_entry.find("=");
-					if (body_entry_separator_pos == std::string::npos) {
-						break ;
-					}
-					const std::string body_field = body_entry.substr(0, body_entry_separator_pos);
-					const std::string body_value = body_entry.substr(body_entry_separator_pos + 1);
-					_body[body_field] = body_value;
-					buffer->erase(0, body_separator_pos + 1);
-				} while (body_separator_pos != std::string::npos);
+	void	_extract_urlencoded() {
+		size_t body_separator_pos;
+		do {
+			body_separator_pos = _raw_request.find("&");
+			const std::string body_entry = _raw_request.substr(0, body_separator_pos);
+			const size_t body_entry_separator_pos = body_entry.find("=");
+			if (body_entry_separator_pos == std::string::npos) {
+				break ;
 			}
-			else if (form_type->second == "multipart/form-data") {
-			}
-		}
+			const std::string body_field = body_entry.substr(0, body_entry_separator_pos);
+			const std::string body_value = body_entry.substr(body_entry_separator_pos + 1);
+			_body[body_field] = body_value;
+			_raw_request.erase(0, body_separator_pos + 1);
+		} while (body_separator_pos != std::string::npos);
+	}
+
+	void	_extract_multipart() {
+		// size_t boundary = _raw_request.find(_body_boundary);
+		// while (boundary != std::string::npos) {
+		// 	std::string	header_str = _raw_request.substr(0, boundary);
+		// 	size_t		header_name_separator_pos = header_str.find(":");
+		// 	if (header_name_separator_pos == std::string::npos)
+		// 		break;
+		// 	std::string	header_name = header_str.substr(0, header_name_separator_pos);
+		// 	std::string	header_content = header_str.substr(header_name_separator_pos + 1);
+		// 	std::string header_value = _trim(header_content);
+		// 	_headers[header_name] = header_value;
+		// 	buffer->erase(0, header_separator_pos + 2);
+		// 	header_separator_pos = buffer->find("\r\n");
+		// }
+	}
+
+	bool	_bad_request() {
+		std::cout << "Bad request" << std::endl;
+		_closed = true;
+		return false;
+	}
+
+	inline std::string& _rtrim(std::string& s, const char* t = " \t") {
+	    s.erase(s.find_last_not_of(t) + 1);
+	    return s;
+	}
+
+	inline std::string& _ltrim(std::string& s, const char* t = " \t") {
+	    s.erase(0, s.find_first_not_of(t));
+	    return s;
+	}
+
+	inline std::string& _trim(std::string& s, const char* t = " \t") {
+	    return _ltrim(_rtrim(s, t), t);
 	}
 };
 }  // namespace Http

--- a/srcs/models/enums.hpp
+++ b/srcs/models/enums.hpp
@@ -14,6 +14,13 @@ enum EMethods {
 	METHOD_UNKNOWN
 };
 
+enum EPostForm {
+	URLENCODED = 0,
+	MULTIPART,
+	POST_FORMS_TOTAL,
+	POST_FORM_UNKNOWN
+};
+
 enum ERead {
 	READ_OK = 0,
 	READ_EOF,

--- a/srcs/models/enums.hpp
+++ b/srcs/models/enums.hpp
@@ -17,7 +17,8 @@ enum EMethods {
 enum ERead {
 	READ_OK = 0,
 	READ_EOF,
-	READ_ERROR
+	READ_ERROR,
+	READ_WAIT
 };
 
 EMethods	get_method(const std::string& method) {

--- a/srcs/server/poll.hpp
+++ b/srcs/server/poll.hpp
@@ -183,7 +183,9 @@ class Poll {
 		if (ret == Models::READ_EOF || ret == Models::READ_ERROR) {
 			return _delete_client(ev_fd, client);
 		}
-		return _change_epoll_state(ev_fd, EPOLLOUT);
+		else if (ret == Models::READ_OK) {
+			return _change_epoll_state(ev_fd, EPOLLOUT);
+		}
 	}
 	void	_handle_write(int ev_fd) {
 		Client *client = _clients[ev_fd];
@@ -218,9 +220,9 @@ class Poll {
 	}
 
 	void	_delete_client(int ev_fd, Client *client) {
+		epoll_ctl(epoll_fd, EPOLL_CTL_DEL, ev_fd, NULL);
 		delete client;
 		_clients.erase(ev_fd);
-		epoll_ctl(epoll_fd, EPOLL_CTL_DEL, ev_fd, NULL);
 	}
 
 	void	_change_epoll_state(int ev_fd, int state) {


### PR DESCRIPTION
Major update to parsing requests from client: multiline requests, and Post requests with urlencoded and multipart content-type with a content-length (transfer encoding chunk not yet available).

```curl -v http://localhost:8080 -F key1=value1 -F key2=value2``` --> OK!!

```curl -v http://localhost:8080 -F key1=value1 -F upload=@localfilename``` --> Not working yet...

It could be refactored to have a better separation between client and request, and to have a much more clean code around handling request status (if a request is still pending, or finished). Therefore, it is necessary to make read operations in the read request in client.hpp, if we want to make all read call through a poll!