### PR TITLE
Handle invalid request in request

### DIFF
--- a/srcs/http/request.hpp
+++ b/srcs/http/request.hpp
@@ -174,10 +174,12 @@ class Request {
 			return _invalid_request(Models::BAD_REQUEST);
 		const std::string method_str = _raw_request.substr(0, method_separator_pos);
 		_method = Models::get_method(method_str);
+		_raw_request.erase(0, method_separator_pos + 1);
 		if (_method == Models::METHOD_UNKNOWN)
 			return _invalid_request(Models::BAD_REQUEST);
-		_raw_request.erase(0, method_separator_pos + 1);
-		if (_method == Models::GET || _method == Models::POST || _method == Models::DELETE)
+		if (_method == Models::GET
+			|| _method == Models::POST
+			|| _method == Models::DELETE)
 			return true;
 		return _invalid_request(Models::NOT_IMPLEMENTED);
 	}

--- a/srcs/models/enums.hpp
+++ b/srcs/models/enums.hpp
@@ -8,8 +8,14 @@ namespace Models {
 
 enum EMethods {
 	GET = 0,
+	HEAD,
 	POST,
+	PUT,
 	DELETE,
+	CONNECT,
+	OPTIONS,
+	TRACE,
+	PATCH,
 	METHODS_TOTAL,
 	METHOD_UNKNOWN
 };
@@ -28,13 +34,33 @@ enum ERead {
 	READ_WAIT
 };
 
+enum ECode {
+	NOCODE = 0,
+	BAD_REQUEST = 400,
+	PAYLOAD_TOO_LARGE = 413,
+	NOT_IMPLEMENTED = 501,
+	HTTP_VERSION_NOT_SUPPORTED = 505
+};
+
 EMethods	get_method(const std::string& method) {
 	if (method == "GET")
 		return GET;
+	else if (method == "HEAD")
+		return HEAD;
 	else if (method == "POST")
 		return POST;
+	else if (method == "PUT")
+		return PUT;
 	else if (method == "DELETE")
 		return DELETE;
+	else if (method == "CONNECT")
+		return CONNECT;
+	else if (method == "OPTIONS")
+		return OPTIONS;
+	else if (method == "TRACE")
+		return TRACE;
+	else if (method == "PATCH")
+		return PATCH;
 	else
 		return METHOD_UNKNOWN;
 }


### PR DESCRIPTION
- Add unsupported methods to EMethod, to handling unimplemented error messages.
- Add a ECode enum, and remove _bad_request() to replace it with _invalid_request(ECode), to handling invalid request.

- Close #8 
- Close #9 
- Close #42 